### PR TITLE
Fix #86

### DIFF
--- a/packages/react/types/index.d.ts
+++ b/packages/react/types/index.d.ts
@@ -12,7 +12,7 @@ export const SubspaceProvider: React.Component<SubspaceProviderProps>;
 
 export class observe extends React.Component<P> {}
 
-export default function useSubspace(): Subspace;
+export function useSubspace(): Subspace;
 
 interface withSubspaceProps {
   subspace: Subspace;


### PR DESCRIPTION
Ty[e declarations for  `subspace-react` are currently broken because of `useSubspace` default export.

Fixes #86 so that useSubspace isn't exported as default type for Typescript projects and can therefore be imported as a named import.  